### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -33,7 +33,7 @@ jobs:
         draft: false
         prerelease: false
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: rwang778/wine-quality-predictor-dockerfile # change this to your DockerHub username and repository
         username: ${{ secrets.DOCKER_USERNAME }} # you need to add your Docker username to this GitHub repo as a secret

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Alex Truong Hai Yen | [athy9193](https://github.com/athy9193)
 Rui Wang |[wang-rui](https://github.com/wang-rui)
 Sang Yoon Lee |[rissangs](https://github.com/rissangs)
 
-Second milestone of a data analysis project for DSCI 522: Data Science workflows, part of Master of Data Science program at the University of British Columbia.
+A data analysis project for DSCI 522: Data Science workflows, part of Master of Data Science program at the University of British Columbia.
 
 ## About
 


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore